### PR TITLE
Add sow template for Claude

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,19 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when creating GitHub issues.
 
+You are an expert technical communicator who specializes in two key areas:
+
+1. Creating precise GitHub issues that follow engineering best practices with clear acceptance criteria, technical requirements, and implementation details appropriate for experienced developers.
+2. Drafting professional business documents (statements of work, proposals, etc.) for a software development consulting company that effectively communicate technical scope, deliverables, and value to both technical and non-technical stakeholders.
+
+For all content, prioritize clarity, specificity, and actionable details while maintaining a direct, professional tone.
+
 ## Repository Structure
 - The current folder is the special GitHub `.github` repository containing GitHub issue templates and possibly other GitHub-related files for the whole organization.
-- The current folder contains hidden directories starting with `.` (like `.github/`)
+- The current folder contains a hidden directory `.github/`.
 - When searching for files, always include hidden files and directories
-- Issue templates are maintained in YAML format in `.github/ISSUE_TEMPLATE/`
+- GitHub issue templates are maintained in YAML format in `.github/ISSUE_TEMPLATE/`
+- Professional business document templates are in in the folder `docs-template`
 
 ## GitHub Issue Standards
 - When creating GitHub issues for any SixFeetUp repository, use the templates from THIS repository (dot-github)
@@ -21,14 +29,18 @@ This file provides guidance to Claude Code (claude.ai/code) when creating GitHub
 - Include emoji in issue titles (like 🐞, ✨, 🌵, 🛠️) matching the template emoji
 - Use the GitHub CLI (`gh`) to create issues directly without opening in the browser
 - Format the issue body according to the template's structure and fields
+- If a transcript was used to create the issue, reference the transcript file in the issue description
 
 ## GitHub issue creation
 - When creating issues with GitHub CLI, use `--repo` to specify the repository and omit the `--web` flag to create the issue completely via CLI
 - NEVER guess the repo name. If it's not provided, then ask for it before trying to create the issue.
 - Open the issue in my web browser after you created it using `gh issue view --web`
 
-## GitHub description rules
+## GitHub issue description rules
 - DO NOT ESCAPE special characters except `"`
+
+## Professional Business Document Standards
+- When creating professional business documents for any SixFeetUp repository, use the templates from THIS repository (dot-github)
 
 ## Commands
 - No specific build/lint/test commands for this repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ For all content, prioritize clarity, specificity, and actionable details while m
 - The current folder contains a hidden directory `.github/`.
 - When searching for files, always include hidden files and directories
 - GitHub issue templates are maintained in YAML format in `.github/ISSUE_TEMPLATE/`
-- Professional business document templates are in in the folder `docs-template`
+- Professional business document templates are in in the folder `docs-templates`
 
 ## GitHub Issue Standards
 - When creating GitHub issues for any SixFeetUp repository, use the templates from THIS repository (dot-github)

--- a/docs-templates/statement-of-work_multi-phases.md
+++ b/docs-templates/statement-of-work_multi-phases.md
@@ -1,0 +1,46 @@
+# [Project Name]
+
+## Executive Summary
+
+This Statement of Work outlines the proposed [brief project description]. The project will be delivered in [number] phases, each building upon the previous to [high-level benefits and outcomes].
+
+## Background
+
+[Provide context about the current state, challenges, and the need for this project. Include information about existing systems or processes if applicable.]
+
+## Phase [Number]: [Phase Name]
+
+**Objective:** [Concise description of what this phase aims to accomplish and the value it delivers to stakeholders]
+
+**Key Deliverables:**
+
+1. [Deliverable Name] - Estimated effort: [XX pts]
+   - [Specific component or feature]
+   - [Specific component or feature]
+   - [Expected outcomes or benefits]
+
+2. [Deliverable Name] - Estimated effort: [XX pts]
+   - [Specific component or feature]
+   - [Specific component or feature]
+   - [Expected outcomes or benefits]
+
+3. [Deliverable Name] - Estimated effort: [XX pts]
+   - [Specific component or feature]
+   - [Specific component or feature]
+   - [Expected outcomes or benefits]
+
+## Phase [Number]: [Phase Name]
+
+**Objective:** [Concise description of what this phase aims to accomplish and the value it delivers to stakeholders]
+
+**Key Deliverables:**
+
+1. [Deliverable Name]
+   - [Specific component or feature]
+   - [Specific component or feature]
+   - [Expected outcomes or benefits]
+
+2. [Deliverable Name]
+   - [Specific component or feature]
+   - [Specific component or feature]
+   - [Expected outcomes or benefits]

--- a/docs-templates/statement-of-work_single-phase.md
+++ b/docs-templates/statement-of-work_single-phase.md
@@ -1,0 +1,30 @@
+# [Project Name]
+
+## Executive Summary
+
+This Statement of Work outlines the proposed [brief project description]. The project will be delivered in [number] phases, each building upon the previous to [high-level benefits and outcomes].
+
+## Background
+
+[Provide context about the current state, challenges, and the need for this project. Include information about existing systems or processes if applicable.]
+
+## Scope
+
+**Objective:** [Concise description of what this phase aims to accomplish and the value it delivers to stakeholders]
+
+**Key Deliverables:**
+
+1. [Deliverable Name] - Estimated effort: [XX pts]
+   - [Specific component or feature]
+   - [Specific component or feature]
+   - [Expected outcomes or benefits]
+
+2. [Deliverable Name] - Estimated effort: [XX pts]
+   - [Specific component or feature]
+   - [Specific component or feature]
+   - [Expected outcomes or benefits]
+
+3. [Deliverable Name] - Estimated effort: [XX pts]
+   - [Specific component or feature]
+   - [Specific component or feature]
+   - [Expected outcomes or benefits]


### PR DESCRIPTION
## :dart: What needed to be done and why?

This is a proposal to have more than GitHub issue templates in this repository.
This provides a very simple way for anybody to create SOWs with the same format.

## :new: What is changed by this PR?

Make the Claude prompt capable of create GitHub issues and SOWs.
