### PR TITLE
feat: use "resolves" #123 to link PR to issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## :dart: What needed to be done and why?
 
-Ticket: #123
+resolves #123
 (Also in the title)
 
 *Quick summary of the issue*


### PR DESCRIPTION
## :dart: What needed to be done and why?

The PR template up to now had "Ticket: #123" because we didn't want to always link PRs due to the auto-close of issues.
Now we can link a PR to an issue and not close the issue on linked PR merge so we can always link.

## :new: What is changed by this PR?

The PR template now has "resolves #123" which is the trigger word to link to the issue #123 in this example.

