### PR TITLE
fix: remove the effort levels from SOW templates

### DIFF
--- a/docs-templates/statement-of-work_multi-phases.md
+++ b/docs-templates/statement-of-work_multi-phases.md
@@ -14,17 +14,17 @@ This Statement of Work outlines the proposed [brief project description]. The pr
 
 **Key Deliverables:**
 
-1. [Deliverable Name] - Estimated effort: [XX pts]
+1. [Deliverable Name]
    - [Specific component or feature]
    - [Specific component or feature]
    - [Expected outcomes or benefits]
 
-2. [Deliverable Name] - Estimated effort: [XX pts]
+2. [Deliverable Name]
    - [Specific component or feature]
    - [Specific component or feature]
    - [Expected outcomes or benefits]
 
-3. [Deliverable Name] - Estimated effort: [XX pts]
+3. [Deliverable Name]
    - [Specific component or feature]
    - [Specific component or feature]
    - [Expected outcomes or benefits]

--- a/docs-templates/statement-of-work_single-phase.md
+++ b/docs-templates/statement-of-work_single-phase.md
@@ -14,17 +14,17 @@ This Statement of Work outlines the proposed [brief project description]. The pr
 
 **Key Deliverables:**
 
-1. [Deliverable Name] - Estimated effort: [XX pts]
+1. [Deliverable Name]
    - [Specific component or feature]
    - [Specific component or feature]
    - [Expected outcomes or benefits]
 
-2. [Deliverable Name] - Estimated effort: [XX pts]
+2. [Deliverable Name]
    - [Specific component or feature]
    - [Specific component or feature]
    - [Expected outcomes or benefits]
 
-3. [Deliverable Name] - Estimated effort: [XX pts]
+3. [Deliverable Name]
    - [Specific component or feature]
    - [Specific component or feature]
    - [Expected outcomes or benefits]


### PR DESCRIPTION
These will be provided in the map view estimates sent along the SOW

## :dart: What needed to be done and why?

Remove the effort level from the SOW templates because those are provided in the Map View estimates sent to the client along with the SOW
